### PR TITLE
ADD: displaying lighthouse audit results

### DIFF
--- a/src/components/AuditResultsButton.js
+++ b/src/components/AuditResultsButton.js
@@ -1,0 +1,53 @@
+import React, { Fragment, Component } from 'react'
+import { Icon, Button, Tooltip, Typography } from 'antd'
+
+const { Text } = Typography
+
+class AuditResultsButton extends Component {
+  state = {
+    auditSummary: {}
+  }
+
+  componentDidMount() {
+    const { lighthouseSummaryLink } = this.props
+    if (lighthouseSummaryLink) {
+      window.fetch(lighthouseSummaryLink).then(result => result.json()).then(auditSummary => this.setState({ auditSummary }))
+    }
+  }
+
+  getTextTypeForScore = (score) => {
+    let className
+
+    if (score < 50) className = 'danger'
+    else if (score < 80) className = 'warning'
+
+    return className
+  }
+
+  render() {
+    const { lighthouseReportLink } = this.props
+    const auditSummary = Object.entries(this.state.auditSummary).reduce((map, [category, score]) => ({ ...map, [category]: Math.floor(score * 100) }), {})
+    if (!lighthouseReportLink) return null
+
+    const summaryInformation = Object.keys(auditSummary).length > 0
+      ? (
+        <Fragment>
+          <span><Icon type='clock-circle' /> <Text type={this.getTextTypeForScore(auditSummary.performance)}>{auditSummary.performance}</Text></span> &nbsp;
+          <span><Icon type='user' /> <Text type={this.getTextTypeForScore(auditSummary.accessibility)}>{auditSummary.accessibility}</Text></span> &nbsp;
+          <span><Icon type='check' /> <Text type={this.getTextTypeForScore(auditSummary['best-practices'])}>{auditSummary['best-practices']}</Text></span>
+        </Fragment>
+      )
+      : <Icon type='loading' />
+
+    console.log(summaryInformation)
+    return (
+      <Tooltip title='View Lighthouse Audit Report'>
+        <Button type='default' href={lighthouseReportLink} target='_blank' rel='noopener'>
+          { summaryInformation }
+        </Button>
+      </Tooltip>
+    )
+  }
+}
+
+export default AuditResultsButton

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -4,6 +4,7 @@ import copy from 'copy-to-clipboard'
 import { getRecordClass, getFormatTime, getExistKeys } from '@/untils'
 import DetailTable from './DetailTable'
 import ErrorButton from './ErrorButton'
+import AuditResultsButton from './AuditResultsButton'
 
 // export const file = '/Users/harry.hou/Desktop/harry/salesforce/salesforce-cti-widget/'
 import { Consumer } from '../contexts/expand'
@@ -108,6 +109,12 @@ const getColumns = (rootDir) => [
           return (testExecError || numFailingTests > 0 || numPendingTests > 0)
       }
     },
+  },
+  {
+    width: '100px',
+    title: 'Quality Audit',
+    key: 'audit',
+    render: ({ lighthouseReportLink, lighthouseSummaryLink }) => <AuditResultsButton lighthouseReportLink={lighthouseReportLink} lighthouseSummaryLink={lighthouseSummaryLink} />
   },
   {
     width: '100px',

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -112,7 +112,7 @@ const getColumns = (rootDir) => [
   },
   {
     width: '100px',
-    title: 'Quality Audit',
+    title: 'Lighthouse Audit',
     key: 'audit',
     render: ({ lighthouseReportLink, lighthouseSummaryLink }) => <AuditResultsButton lighthouseReportLink={lighthouseReportLink} lighthouseSummaryLink={lighthouseSummaryLink} />
   },


### PR DESCRIPTION
This PR adds in the ability to parse and display lighthouse audit reports if they exist for a given test

You can see the diff adding the ability to create these reports at https://phabricator.dkandu.me/D95055#change-CCSX4HDjKTV

And see what the integrated reports look like in my MAT pitch video here: https://www.youtube.com/watch?v=rRq7xKXBGiY&feature=youtu.be