### PR TITLE
Using template interpolation syntax for the report data

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <div id="app">
   </div>
   <script>
-    window.resData = $resultData
+    window.resData = JSON.stringify(<%= reportData %>)
   </script>
 </body>
 


### PR DESCRIPTION
## Summary

As exposed in https://github.com/webedx-spark/r2/pull/1204, using a straight-up String.prototype.replace in `main.js` is problematic because there are special escape characters^1 in the `replace` function that cause the output of that data to get repeated numerous times into the HTML. This resolves the issue by moving to `lodash.template` interpolation instead.


[^1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter

